### PR TITLE
Add functionality to not include outer word boundaries

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -24,20 +24,20 @@ struct StartFlag{GT} <: AbstractFlag{GT}
   flag::String
   flag_boundaries_left::Vector{String}
   flag_boundaries_right::Vector{String}
-  trigger::Vector{String}
+  trigger::Dict{Tuple,String}
 end
 function StartFlag(flag::S,
   flag_boundaries_left=S[],
   flag_boundaries_right=S[];
   grep_type::AbstractGrepType=GreedyType()
   ) where {S<:AbstractString, GT<:AbstractGrepType}
-  trigger = Vector{String}()
+  trigger = Dict{Tuple,String}()
   for left in flag_boundaries_left
     for right in flag_boundaries_right
-      push!(trigger, string(left, flag, right))
+      trigger[(left,right)] = string(left, flag, right)
     end
   end
-  isempty(trigger) && push!(trigger, flag)
+  isempty(trigger) && (trigger[("","")] = flag)
   return StartFlag{typeof(grep_type)}(flag, flag_boundaries_left,
         flag_boundaries_right, trigger)
 end
@@ -54,20 +54,20 @@ struct StopFlag{GT} <: AbstractFlag{GT}
   flag::String
   flag_boundaries_left::Vector{String}
   flag_boundaries_right::Vector{String}
-  trigger::Vector{String}
+  trigger::Dict{Tuple,String}
 end
 function StopFlag(flag::S,
   flag_boundaries_left=S[],
   flag_boundaries_right=S[];
   grep_type::AbstractGrepType=GreedyType()
   ) where {S<:AbstractString}
-  trigger = Vector{String}()
+  trigger = Dict{Tuple,String}()
   for left in flag_boundaries_left
     for right in flag_boundaries_right
-      push!(trigger, string(left, flag, right))
+      trigger[(left,right)] = string(left, flag, right)
     end
   end
-  isempty(trigger) && push!(trigger, flag)
+  isempty(trigger) && (trigger[("","")] = flag)
   return StopFlag{typeof(grep_type)}(flag, flag_boundaries_left,
         flag_boundaries_right, trigger)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,10 +11,23 @@ if export_results
 end
 
 @testset "BetweenFlags" begin
-    include(joinpath("unit","flags.jl"))
-    include(joinpath("unit","flag_pair.jl"))
-    include(joinpath("unit","tokenize.jl"))
+  @testset "Unit tests" begin
+    @testset "Flags" begin
+      include(joinpath("unit","flags.jl"))
+      include(joinpath("unit","flag_pair.jl"))
+    end
+    @testset "Tokenize - with boundaries" begin
+      include(joinpath("unit","tokenize.jl"))
+    end
+    @testset "Tokenize - no outer boundaries" begin
+      include(joinpath("unit","tokenize_no_outer_boundaries.jl"))
+    end
+  end
+  @testset "Data-driven tests" begin
     include(joinpath("data_driven","tokenize.jl"))
+  end
+  @testset "Performance tests" begin
     include(joinpath("perf","perf.jl"))
+  end
 end
 

--- a/test/unit/flags.jl
+++ b/test/unit/flags.jl
@@ -7,7 +7,7 @@ using BetweenFlags
         @test flag.flag == "flag"
         @test flag.flag_boundaries_left == []
         @test flag.flag_boundaries_right == []
-        @test flag.trigger == ["flag"]
+        @test flag.trigger == Dict{Tuple,String}(("", "") => "flag")
         @test BetweenFlags.grep_type(flag) == GreedyType
 
         flag = Flag("flag",
@@ -17,7 +17,11 @@ using BetweenFlags
         @test flag.flag == "flag"
         @test flag.flag_boundaries_left == ["LB1","LB2"]
         @test flag.flag_boundaries_right == ["RB1","RB2"]
-        @test flag.trigger ==  ["LB1flagRB1", "LB1flagRB2", "LB2flagRB1", "LB2flagRB2"]
+        @test flag.trigger == Dict{Tuple,String}(
+            ("LB2", "RB1") => "LB2flagRB1",
+            ("LB2", "RB2") => "LB2flagRB2",
+            ("LB1", "RB2") => "LB1flagRB2",
+            ("LB1", "RB1") => "LB1flagRB1")
         @test BetweenFlags.grep_type(flag) == ScopeType
 
         flag = Flag("flag",
@@ -27,7 +31,11 @@ using BetweenFlags
         @test flag.flag == "flag"
         @test flag.flag_boundaries_left == ["LB1","LB2"]
         @test flag.flag_boundaries_right == ["RB1","RB2"]
-        @test flag.trigger ==  ["LB1flagRB1", "LB1flagRB2", "LB2flagRB1", "LB2flagRB2"]
+        @test flag.trigger == Dict{Tuple,String}(
+            ("LB2", "RB1") => "LB2flagRB1",
+            ("LB2", "RB2") => "LB2flagRB2",
+            ("LB1", "RB2") => "LB1flagRB2",
+            ("LB1", "RB1") => "LB1flagRB1")
         @test BetweenFlags.grep_type(flag) == ScopeType
     end
 end

--- a/test/unit/tokenize_no_outer_boundaries.jl
+++ b/test/unit/tokenize_no_outer_boundaries.jl
@@ -1,0 +1,123 @@
+using Test
+using BetweenFlags
+import BetweenFlags
+
+@testset "Greedy - length(flag)>length(word bc)" begin
+  flag_set = FlagSet([
+      FlagPair{GreedyType}(
+          StartFlag("{", ["*"], [""]),
+          StopFlag( "}", [""], ["*"])
+      )
+  ])
+
+  text = "Foo, bar..."
+  token_stream = TokenStream(text, flag_set)
+  @test token_stream("{-}") == ""
+
+  text = "Foo,*{}*, bar..."
+  token_stream = TokenStream(text, flag_set; rm_outer_bcs=true)
+  @test token_stream("{-}") == "{}"
+
+  text = "Foo,*{a}{b}*, bar..."
+  token_stream = TokenStream(text, flag_set; rm_outer_bcs=true)
+  @test token_stream("{-}") == "{a}{b}"
+
+  text = "Foo, *{a} {b}*, bar..."
+  token_stream = TokenStream(text, flag_set; rm_outer_bcs=true)
+  # Consecutive scopes are concatenated (in `get_string`):
+  @test token_stream("{-}") == "{a} {b}"
+
+  text = "Foo, *{bar}*, foobar..."
+  token_stream = TokenStream(text, flag_set; rm_outer_bcs=true)
+  @test token_stream("{-}") == "{bar}"
+
+  text = "Foo, *{{foobar}*}, foobaz..."
+  token_stream = TokenStream(text, flag_set; rm_outer_bcs=true)
+  @test token_stream("{-}") == "{{foobar}"
+end
+
+@testset "Scope - flag subsets" begin
+  flag_set = FlagSet([
+      FlagPair{ScopeType}(
+          StartFlag("do", ["*"], [""]),
+          StopFlag( "end do", [""], ["*"])
+      )
+  ])
+  text = "Foo, *do bar; foo end do*, foobar..."
+  token_stream = TokenStream(text, flag_set; rm_outer_bcs=true)
+  @test token_stream("do-end do") == "do bar; foo end do"
+end
+
+@testset "Scope - nested" begin
+  flag_set = FlagSet([
+      FlagPair{ScopeType}(
+          StartFlag("{", ["*"], [""]),
+          StopFlag( "}", [""], ["*"])
+      )
+  ])
+
+  text = "Foo, *{bar}*, foobar..."
+  token_stream = TokenStream(text, flag_set; rm_outer_bcs=true)
+  @test token_stream("{-}") == "{bar}"
+
+  text = "Foo, *{{bar}}*, foobar..."
+  token_stream = TokenStream(text, flag_set; rm_outer_bcs=true)
+  @test token_stream("{-}") == "{{bar}}"
+
+  text = "Foo, *{{bar}{baz}}*, foobar..."
+  token_stream = TokenStream(text, flag_set; rm_outer_bcs=true)
+  @test token_stream("{-}") == "{{bar}{baz}}"
+
+end
+
+@testset "Greedy - length(flag)==length(word bc)" begin
+  flag_set = FlagSet([
+      FlagPair{GreedyType}(
+          StartFlag("ABC_ABC_L", ["STA_WBC_L"], ["STA_WBC_R"]),
+          StopFlag( "ABC_ABC_R", ["STO_WBC_L"], ["STO_WBC_R"])
+      )
+  ])
+
+  text = "foo STA_WBC_LABC_ABC_LSTA_WBC_R bar STO_WBC_LABC_ABC_RSTO_WBC_R foobar"
+  token_stream = TokenStream(text, flag_set; rm_outer_bcs=true)
+  @test token_stream("ABC_ABC_L-ABC_ABC_R") == "ABC_ABC_LSTA_WBC_R bar STO_WBC_LABC_ABC_R"
+
+end
+
+@testset "Greedy - length(flag)<length(word bc)" begin
+  flag_set = FlagSet([
+      FlagPair{GreedyType}(
+          StartFlag("ABC_L", ["XYZ_XYZ_STA_WBC_L"], ["XYZ_XYZ_STA_WBC_R"]),
+          StopFlag( "ABC_R", ["XYZ_XYZ_STO_WBC_L"], ["XYZ_XYZ_STO_WBC_R"])
+      )
+  ])
+
+  text = "foo XYZ_XYZ_STA_WBC_LABC_LXYZ_XYZ_STA_WBC_R bar XYZ_XYZ_STO_WBC_LABC_RXYZ_XYZ_STO_WBC_R foobar"
+  token_stream = TokenStream(text, flag_set; rm_outer_bcs=true)
+  @test token_stream("ABC_L-ABC_R") == "ABC_LXYZ_XYZ_STA_WBC_R bar XYZ_XYZ_STO_WBC_LABC_R"
+
+end
+
+@testset "start_flag == stop_flag, same word bcs" begin
+  flag_set = FlagSet([
+        FlagPair{GreedyType}(
+        StartFlag("|", ["*"], [" "]),
+        StopFlag( "|", [" "], ["*"])
+        )
+        ])
+  text = "baz*| foo |*baz*| bar |*foobaz"
+  token_stream = TokenStream(text, flag_set; rm_outer_bcs=true)
+  @test token_stream("|-|") == "| foo || bar |"
+end
+
+@testset "Unicode" begin
+  flag_set = FlagSet([
+        FlagPair{GreedyType}(
+        StartFlag("|", ["*"], [" "]),
+        StopFlag( "|", [" "], ["*"])
+        )
+        ])
+  text = "baz*| θ |*baz*| ϕ |*foobaz"
+  token_stream = TokenStream(text, flag_set; rm_outer_bcs=true)
+  @test token_stream("|-|") == "| θ || ϕ |"
+end


### PR DESCRIPTION
Add a kwarg to optionally remove the outer word boundaries when tokenizing. This is a bit of a hack, but it should work for now. Partially addresses #16.